### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hi there! This is just a simple little WebExtension that shows Goodreads ratings
 ## Permissions
 The add-on only activates on Overdrive library pages and accesses the Goodreads API.
 ```
-*://*.overdrive.com/media/*
+*://*.overdrive.com/*/media/*
 *://*.goodreads.com/*
 ```
 ## Installation

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
 	},
 	"content_scripts": [
 	{
-		"matches": ["*://*.overdrive.com/media/*"],
+		"matches": ["*://*.overdrive.com/*/media/*"],
 		"js": ["overdrive_goodreads.js"],
 		"css": ["overdrive_goodreads.css"]
 	}


### PR DESCRIPTION
My overdrive URI looks something like this:
https://mlc.overdrive.com/mlc-plymouth/content/media/1895787

That doesn't seem to match the existing path matcher, so I've updated it to be a little looser.